### PR TITLE
Documentation fix: gem include line to public repository

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -18,7 +18,7 @@ h3. Installation
 
 Add to project's Gemfile:
 <pre><code>
-gem 'mail_chimp', '>=1.3', :git => 'https://sbeam@github.com/sbeam/spree-mail-chimp.git'
+gem 'mail_chimp', '>=1.3', :git => 'git://github.com/sbeam/spree-mail-chimp.git'
 </code> </pre>
 
 Run from project's root:


### PR DESCRIPTION
Your readme referenced to your private git-url, not the public accesible one. Changed in this small commit.
