### PR TITLE
Solve Precompile issue with spree 1.0.3

### DIFF
--- a/app/views/spree/admin/mail_chimp_settings/edit.html.erb
+++ b/app/views/spree/admin/mail_chimp_settings/edit.html.erb
@@ -1,5 +1,5 @@
 <%= content_for :head do %>
-  <%= javascript_include_tag "jquery.validate.min" %>
+  <%= javascript_include_tag "jquery.validate/jquery.validate.min" %>
 <% end -%>
 
 <%= render :partial => 'spree/admin/shared/configuration_menu' %>


### PR DESCRIPTION
In spree 1.0.3 the validate.min.js is in a subdirectory which causes a "isn't precompiled" exception when trying to change Mail Chimp settings. 
This solves the issue for me with spree 1.0.3 but I assume this again might cause some problems with versions < 1.0.3
