### PR TITLE
Update admin override for admin

### DIFF
--- a/app/overrides/add_mail_chimp_admin_menu_link.rb
+++ b/app/overrides/add_mail_chimp_admin_menu_link.rb
@@ -1,4 +1,6 @@
-Deface::Override.new(:virtual_path  => 'spree/admin/configurations/index',
+Deface::Override.new(:virtual_path  => 'spree/admin/shared/_configuration_menu',
                      :name          => 'add_mail_chimp_admin_menu_link',
-                     :insert_bottom => "[data-hook='admin_configurations_menu']",
-                     :partial       => 'spree/admin/configurations/spree_mail_chimp_configuration_link' )
+                     :insert_bottom => "[data-hook='admin_configurations_sidebar_menu']",
+                    :text => %q{
+                        <%= configurations_sidebar_menu_item 'Mail Chimp', admin_mail_chimp_settings_path %>
+                     }) 


### PR DESCRIPTION
Updated the override for the admin configurations menu to work with spree 1.3
